### PR TITLE
18 coverage report not generated properly (#19)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ "main", "7-add-unit-tests" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -29,7 +29,7 @@ jobs:
       - name: Test with pytest
         run: |
           pip install pytest pytest-cov
-          pytest --cov-report=xml --cov=symbolic_pofk tests/test_syren.py
+          python3 tests/run.py
           cat coverage.xml
         shell: bash
 

--- a/tests/run.py
+++ b/tests/run.py
@@ -1,0 +1,21 @@
+import os
+import symbolic_pofk
+import subprocess
+
+def run_tests():
+    # Get the path to the symbolic_pofk module
+    symbolic_pofk_path = os.path.dirname(symbolic_pofk.__file__)
+    
+    # Construct the pytest command with the correct coverage path
+    pytest_command = [
+        'pytest',
+        '--cov-report=xml',
+        f'--cov={symbolic_pofk_path}',
+        'tests/test_syren.py'
+    ]
+    
+    # Run pytest
+    subprocess.run(pytest_command)
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
* Add path to true symbolic_pofk

* Run unit tests on 18-coverage-report-not-generated-properly

* Remove need to run unit tests on 18-coverage-report-not-generated-properly